### PR TITLE
Fixes typo on translation key

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -247,7 +247,7 @@ en:
     assistants:
       one:                  "1 assistant"
       other:                "%{count} assistants"
-    archived:                "Archive this meetup"
+    archive:                "Archive this meetup"
     edit:                   "Edit"
     destroy:                "Cancel"
     unvote:                 "Have you changed your mind? Don't worry, you can undo your vote"


### PR DESCRIPTION
As stated on #95, the archived meetup checkbox is missing translation as the image shows:

![image](https://user-images.githubusercontent.com/3200560/46323948-41542f00-c5c7-11e8-8a2b-574c1e05e3e4.png)

The main cause was that in [this](https://github.com/infusionvlc/infusion/blob/master/config/locales/es.yml) spanish archive, the translation key is marked as `archive` not `archived`, just a typo.