### PR TITLE
Added a basic dashboard for handling dates in the queue

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
 class EventsController < ApplicationController
-  before_action :set_event, only: %i[show edit update destroy]
+  before_action :set_event, only: %i[destroy]
 
   include MarkdownConcern
-
-  def show; end
 
   def new
     @event = Event.new
@@ -23,7 +21,8 @@ class EventsController < ApplicationController
   end
 
   def index
-    @events = Event.where('date >= ?', Date.today).order(date: :asc).page(params[:page])
+    @events = Event.where('date >= ?', Date.today)
+                   .order(date: :asc).page(params[:page])
     authorize @events
   end
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+class EventsController < ApplicationController
+  before_action :set_event, only: %i[show edit update destroy]
+
+  include MarkdownConcern
+
+  def show; end
+
+  def new
+    @event = Event.new
+    authorize @event
+  end
+
+  def create
+    @event = Event.new(event_params)
+    authorize @event
+    if @event.save
+      ok_status
+    else
+      error_status
+    end
+  end
+
+  def index
+    @events = Event.where('date >= ?', Date.today).page(params[:page])
+    authorize @events
+  end
+
+  def destroy
+    authorize @event
+    @event.destroy
+    redirect_to events_path
+  end
+
+  private
+
+  def event_params
+    params.require(:event).permit(:date)
+  end
+
+  def set_event
+    @event = Event.find(params[:id])
+  rescue StandardError
+    redirect_to events_path
+  end
+
+  def ok_status
+    respond_to do |format|
+      format.html { redirect_to events_path }
+      format.json { render :show, status: :created, event: @event }
+    end
+  end
+
+  def error_status
+    format.html { render :new }
+    format.json { render json: @event.errors, status: :unprocessable_entity }
+  end
+end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -23,7 +23,7 @@ class EventsController < ApplicationController
   end
 
   def index
-    @events = Event.where('date >= ?', Date.today).page(params[:page])
+    @events = Event.where('date >= ?', Date.today).order(date: :asc).page(params[:page])
     authorize @events
   end
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -5,4 +5,12 @@ class Event < ApplicationRecord
   has_many :meetups, through: :sessions
 
   validates :date, uniqueness: true
+
+  validate :date_is_in_the_future, :on => :create
+
+  private
+
+  def date_is_in_the_future
+    date >= Date.today
+  end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -6,7 +6,7 @@ class Event < ApplicationRecord
 
   validates :date, uniqueness: true
 
-  validate :date_is_in_the_future, :on => :create
+  validate :date_is_in_the_future, on: :create
 
   private
 

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class EventPolicy
+  attr_reader :user, :event
+
+  def initialize(user, event)
+    @user = user
+    @event = event
+  end
+
+  def index?
+    @user&.admin?
+  end
+
+  def create?
+    @user&.admin?
+  end
+
+  def new?
+    @user&.admin?
+  end
+
+  def update?
+    @user&.admin?
+  end
+
+  def destroy?
+    @user&.admin?
+  end
+end

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,5 +1,5 @@
 <%= link_to new_event_path, class:'btn btn-primary right' do %>
-  <%= fa_icon 'plus' %> <%= I18n.t 'main.add' %>
+  <%= icon('fas', 'plus') %> <%= I18n.t 'main.add' %>
 <% end %>
 
 <h1><%= I18n.t 'activerecord.model.event.other' %></h1>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,0 +1,19 @@
+<%= link_to new_event_path, class:'btn btn-primary right' do %>
+  <%= fa_icon 'plus' %> <%= I18n.t 'main.add' %>
+<% end %>
+
+<h1><%= I18n.t 'activerecord.model.event.other' %></h1>
+<br/>
+<% @events.each do |event| %>
+  <div class="card">
+    <div class="card-body">
+      <h2>
+        <%= event.date %>
+        <%= link_to event, method: :delete, class:'btn btn-danger right' do %>
+          <%= I18n.t 'main.delete' %>
+        <% end %>
+      </h2>
+    </div>
+  </div>
+<% end %>
+<%= paginate @events, theme: 'twitter-bootstrap-4' %>

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -1,0 +1,14 @@
+<h1><%=I18n.t 'event.create' %></h1>
+
+<%= form_for(@event) do |f| %>
+  <div class="field">
+    <%= f.label :date %><br>
+    <%= f.date_field :date, class:'form-control' %>
+  </div>
+
+  <br/>
+  <div class="actions">
+    <%= f.submit class: 'btn btn-primary' %>
+  </div>
+<% end %>
+

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -274,8 +274,14 @@ ca:
   session:
     ranking:                "Nova sessió al ranking"
 
+  event:
+    create:                 "Afegeix una nova data per futurs events"
+
   activerecord:
     model:
+      event:
+        one:   "Event"
+        other: "Events"
       user:
         one:   "Usuari"
         other: "Usuaris"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -274,8 +274,14 @@ en:
   session:
     ranking:                "New session currently on ranking"
 
+  event:
+    create:                 "Add a new slot for future events"
+
   activerecord:
     model:
+      event:
+        one:   "Event"
+        other: "Events"
       user:
         one:   "User"
         other: "Users"
@@ -359,7 +365,6 @@ en:
         header:
           one: "It seems like there's some issue with your info"
           other: "It seems like there are %{count} issues with your info"
-
 
   helpers:
     submit:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -275,8 +275,14 @@ es:
   session:
     ranking:                "Nueva sesión en el ranking"
 
+  event:
+    create:                 "Añade una nueva fecha para futuros eventos"
+
   activerecord:
     model:
+      event:
+        one:   "Evento"
+        other: "Eventos"
       user:
         one:   "Usuario"
         other: "Usuarios"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-
   match '/webhook' => 'webhook#reply', via: :post
 
   match 'users/auth/:provider/callback', to: 'sessions#create',        via: [:get, :post]
@@ -28,6 +27,7 @@ Rails.application.routes.draw do
   resources :reports
   resources :activities
   resources :locations
+  resources :events, except: [:edit, :update]
 
   resources :meetups do
     resources :sessions, :controller=>"meetup_sessions" do

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -22,7 +22,7 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
 
   test "should not be able to see the new event form if not an adin" do
     get new_event_path
-    assert_response :success
+    assert_response :redirect
   end
 
   test 'should create new event with date' do

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -1,26 +1,28 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class EventsControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
-  test "should get index if user is admin" do
+  test 'should get index if user is admin' do
     sign_in users(:one)
     get events_path
     assert_response :success
   end
 
-  test "should not get index if user is not admin" do
+  test 'should not get index if user is not admin' do
     get events_path
     assert_response :redirect
   end
 
-  test "should be able to see the new event form if user is admin" do
+  test 'should be able to see the new event form if user is admin' do
     sign_in users(:one)
     get new_event_path
     assert_response :success
   end
 
-  test "should not be able to see the new event form if not an adin" do
+  test 'should not be able to see the new event form if not an admin' do
     get new_event_path
     assert_response :redirect
   end
@@ -39,5 +41,4 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_response :success
   end
-
 end

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -1,0 +1,43 @@
+require 'test_helper'
+
+class EventsControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  test "should get index if user is admin" do
+    sign_in users(:one)
+    get events_path
+    assert_response :success
+  end
+
+  test "should not get index if user is not admin" do
+    get events_path
+    assert_response :redirect
+  end
+
+  test "should be able to see the new event form if user is admin" do
+    sign_in users(:one)
+    get new_event_path
+    assert_response :success
+  end
+
+  test "should not be able to see the new event form if not an adin" do
+    get new_event_path
+    assert_response :success
+  end
+
+  test 'should create new event with date' do
+    post events_path,
+         params: { event: { date: Date.today } }
+    assert_response :redirect
+    follow_redirect!
+    assert_response :success
+  end
+
+  test 'should remove an event' do
+    sign_in users(:one)
+    delete event_path(1)
+    follow_redirect!
+    assert_response :success
+  end
+
+end


### PR DESCRIPTION
### :pushpin: References
* **Issue:** #107 

### :tophat: What is the goal?

Create a basic dashboard only accessible to admins to manage dates in the queue.

### :memo: How is it being implemented?

- Added a couple of actions (`index`, `new`, `create`, `destroy`) to an `events_controller`.
- Created an `EventsPolicy` to check if users are authorised to access the dashboard.
- Wrote a couple of controller tests.

### :boom: How can it be tested?

- [x] **Creating a new date:** 
  - [x] If the current user is not an admin he/she will be redirected to the root path
  - [x] If the date is in the past an error is returned.
- [x] **Seeing dates in the queue** 
 - [x] If the current user is not an admin he/she will be redirected to the root path
- [x] **Remove a date** 
 - [x] If the current user is not an admin he/she will be redirected to the root path
 
### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.  
