### PR TITLE
Change diversity icon to an existing one

### DIFF
--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -35,7 +35,7 @@
         <h3 class="center">
           <span class="fa-stack fa-lg">
             <i class="fas fa-circle fa-stack-2x"></i>
-            <i class="fas fa-diamond fa-stack-1x fa-inverse"></i>
+            <i class="fas fa-universal-access fa-stack-1x fa-inverse"></i>
           </span><br/>
           <%= I18n.t 'landing.values.diversity' %>
         </h3>

--- a/app/views/pages/show_tell.html.erb
+++ b/app/views/pages/show_tell.html.erb
@@ -69,7 +69,7 @@
         <h3 class="center">
           <span class="fa-stack fa-lg">
             <i class="fas fa-circle fa-stack-2x"></i>
-            <i class="fas fa-diamond fa-stack-1x fa-inverse"></i>
+            <i class="fas fa-universal-access fa-stack-1x fa-inverse"></i>
           </span><br/>
           <%= I18n.t 'landing.values.diversity' %>
         </h3>


### PR DESCRIPTION
The current diamond icon only exists in the pro version,
so update it to show a new icon correctly.

Screenshots:
Before:
![image](https://user-images.githubusercontent.com/1099323/54868309-d3581b80-4d50-11e9-8739-206935aecdf9.png)

After:
![image](https://user-images.githubusercontent.com/1099323/54868323-ebc83600-4d50-11e9-9b16-0b77b06804a4.png)

